### PR TITLE
Connect protocol

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,9 @@
 {
 	"recommendations": [
 		"henrynguyen5-vsc.vsc-nvm",
-		"zxh404.vscode-proto3",
 		"dbaeumer.vscode-eslint",
 		"esbenp.prettier-vscode",
 		"ms-azuretools.vscode-docker",
+		"bufbuild.vscode-buf",
 	],
 }


### PR DESCRIPTION
This PR should completely migrate public API to [Connect](https://connect.build/) protocol.  
Currently waiting v1 release with Node.js support. See https://github.com/bufbuild/connect-web/discussions/315